### PR TITLE
#511 Add 'AddHours' scaffolds and initial unit tests

### DIFF
--- a/tock/hours/forms.py
+++ b/tock/hours/forms.py
@@ -83,7 +83,6 @@ class SelectWithData(forms.widgets.Select):
             notes_displayed_html, notes_required_html, alerts_html,
             conditional_escape(force_text(option_label)))
 
-
 def choice_label_for_project(project):
     """
     Returns the label for a project as it should appear in an
@@ -206,6 +205,19 @@ class TimecardObjectForm(forms.ModelForm):
 
         return self.cleaned_data
 
+class AddHoursForm(forms.Form):
+    """Form for Adding Hours to the users unsubmitted timecard"""
+
+    project = forms.ChoiceField(
+        widget=SelectWithData(),
+        choices=projects_as_choices
+        )
+    hours_spent = forms.DecimalField(
+        min_value=0,
+        widget=forms.NumberInput(attrs={
+            'step': '1'
+        })
+    )
 
 class TimecardInlineFormSet(BaseInlineFormSet):
     """This FormSet is used for submissions of timecard entries."""

--- a/tock/hours/forms.py
+++ b/tock/hours/forms.py
@@ -210,14 +210,19 @@ class AddHoursForm(forms.Form):
 
     project = forms.ChoiceField(
         widget=SelectWithData(),
+        required=True,
         choices=projects_as_choices
         )
-    hours_spent = forms.DecimalField(
+    hours = forms.DecimalField(
         min_value=0,
+        required=True,
         widget=forms.NumberInput(attrs={
             'step': '1'
         })
     )
+
+    def clean(self):
+        super(AddHoursForm, self).clean()
 
 class TimecardInlineFormSet(BaseInlineFormSet):
     """This FormSet is used for submissions of timecard entries."""

--- a/tock/hours/tests/test_forms.py
+++ b/tock/hours/tests/test_forms.py
@@ -9,7 +9,7 @@ import projects.models
 from hours.forms import (
     TimecardForm, TimecardObjectForm,
     TimecardFormSet, projects_as_choices,
-    choice_label_for_project
+    choice_label_for_project, AddHoursForm
 )
 
 
@@ -294,3 +294,33 @@ class TimecardInlineFormSetTests(TestCase):
         form_data['timecardobjects-0-notes'] = 'Did some work.'
         formset = TimecardFormSet(form_data)
         self.assertTrue(formset.is_valid())
+
+class AddHoursFormTests(TestCase):
+    fixtures = [
+        'projects/fixtures/projects.json',
+        'tock/fixtures/prod_user.json',
+    ]
+
+    def setUp(self):
+        self.reporting_period = hours.models.ReportingPeriod.objects.create(
+            start_date=datetime.date(2015, 1, 1),
+            end_date=datetime.date(2015, 1, 7),
+            exact_working_hours=40,
+            min_working_hours=40,
+            max_working_hours=60)
+        self.user = get_user_model().objects.get(id=1)
+        self.project_1 = projects.models.Project.objects.get(name="openFEC")
+
+    def test_invalid_form(self):
+        form_data = {}
+        form = AddHoursForm(form_data)
+        self.assertFalse(form.is_valid())
+
+    def test_valid_form(self):
+        form_data = {
+            'project': self.project_1.id,
+            'hours': 2
+        }
+
+        form = AddHoursForm(form_data)
+        self.assertTrue(form.is_valid())

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -20,6 +20,7 @@ from hours.forms import choice_label_for_project
 import hours.models
 import hours.views
 import projects.models
+from collections import OrderedDict
 
 FIXTURES = [
     'tock/fixtures/prod_user.json',
@@ -109,6 +110,38 @@ class BulkTimecardsTests(TestCase):
             self.assertEqual(row['billable'], 'False')
             rows_read += 1
         self.assertNotEqual(rows_read, 0, 'no rows read, expecting 1 or more')
+
+class TestAddHours(WebTest):
+    fixtures = [
+        'projects/fixtures/projects.json',
+        'tock/fixtures/prod_user.json',
+    ]
+    csrf_checks = False
+
+    def setUp(self):
+        self.user = User.objects.get(username='aaron.snow')
+
+    def test_form_shows_correct_fields(self):
+        factory = RequestFactory()
+        request = factory.get(reverse('AddHours'))
+        request.user = self.user
+        hours_view = hours.views.AddHoursView.as_view()
+        response = hours_view(request)
+        field_keys = response.context_data['form'].fields.keys()
+        foo_dict = OrderedDict({'project': 'foo', 'hours_spent': 11})
+        expected_field_keys = foo_dict.keys()
+
+        self.assertEqual(expected_field_keys, field_keys)
+
+    def test_display_error_when_project_does_not_exist(self):
+        factory = RequestFactory()
+        request = factory.get(reverse('AddHours'), {'project_id': 42}, expect_errors=True)
+        request.user = self.user
+        hours_view = hours.views.AddHoursView.as_view()
+        response = hours_view(request)
+        current_project = response.context_data['form'].fields['project']
+
+        self.assertEqual(response.status_code, 404)
 
 class TestAdminBulkTimecards(TestCase):
     fixtures = FIXTURES

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -128,14 +128,13 @@ class TestAddHours(WebTest):
         hours_view = hours.views.AddHoursView.as_view()
         response = hours_view(request)
         field_keys = response.context_data['form'].fields.keys()
-        foo_dict = OrderedDict({'project': 'foo', 'hours_spent': 11})
+        foo_dict = OrderedDict({'project': 'foo', 'hours': 11})
         expected_field_keys = foo_dict.keys()
-
         self.assertEqual(expected_field_keys, field_keys)
 
     def test_display_error_when_project_does_not_exist(self):
         factory = RequestFactory()
-        request = factory.get(reverse('AddHours'), {'project_id': 42}, expect_errors=True)
+        request = factory.get(reverse('AddHours'), kwargs={'project_id': 42, 'hours': 2}, expect_errors=True)
         request.user = self.user
         hours_view = hours.views.AddHoursView.as_view()
         response = hours_view(request)

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -28,6 +28,7 @@ from tock.utils import PermissionMixin, IsSuperUserOrSelf
 
 from .models import ReportingPeriod, Timecard, TimecardObject, Project
 from .forms import (
+    AddHoursForm,
     ReportingPeriodForm,
     ReportingPeriodImportForm,
     projects_as_choices,
@@ -227,6 +228,13 @@ class ReportingPeriodListView(PermissionMixin, ListView):
             unstarted_reporting_periods, unfinished_reporting_periods)),
             key=attrgetter('start_date'))
         return context
+
+class AddHoursView(PermissionMixin, FormView):
+    form_class = AddHoursForm
+    template_name = 'hours/add_hours_form.html'
+    permission_classes = (IsSuperUserOrSelf, )
+
+    # TODO: Add context like it's done on UserFormView
 
 
 class ReportingPeriodCreateView(PermissionMixin, CreateView):

--- a/tock/tock/templates/hours/add_hours_form.html
+++ b/tock/tock/templates/hours/add_hours_form.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<h2>Import Reporting Period!</h2>
+<h2>Add Hours to Project</h2>
 
 <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
     {{ form.as_p }}

--- a/tock/tock/urls.py
+++ b/tock/tock/urls.py
@@ -14,6 +14,10 @@ urlpatterns = [
         hours.views.ReportingPeriodListView.as_view(),
         name='ListReportingPeriods'
     ),
+    url(r'^addHours/$',
+        hours.views.AddHoursView.as_view(),
+        name='AddHours'
+    ),
     url(r'^reporting_period/', include(
         'hours.urls.timesheets',
         namespace='reportingperiod'


### PR DESCRIPTION
# TODO: Update description & Squash commits before making a PR against upstream.

This pr will implement  https://github.com/18F/tock/issues/511

Action items:
* [ ] a. Pass URL query strings to the AddHoursForm on tock/hours/form.py i.e: if we type addHours/?project=1&hours=1 the form must be prepopulated with those values
* [ ] b. Add Validations to the AddHoursForm to only allow submitting when there's a valid project & hours selected.
* [ ] c. Make the Form update the current unsubmitted timecard
* [ ] d. Implementing the Undo functionality
* [ ] e. Add validations to handle when there isn't an active timecard

---------------------
# Details to be updated later:

## Description

Include a high-level description of the issue your pull request fixes; include only one issue per pull request. Link to the GitHub issue it resolves.

## Additional information

Include any of the following (as necessary):

* Relevant research and support documents
* Screenshot images
* Notes

